### PR TITLE
DNSチェックが正常にできていないバグを修正した

### DIFF
--- a/dropcheck
+++ b/dropcheck
@@ -159,13 +159,13 @@ def check_dns_a(DOMAIN_NAME, DNS_SERVER=None):
 		#DNS resolution check
 		if DNS_SERVER is None:
 			result = subprocess.run(["dig", DOMAIN_NAME, "A", "+short"], stdout=subprocess.PIPE)
-			if result.returncode == 0:
+			if result.stdout != b"":
 				print("IPv4DNS resolution to", DOMAIN_NAME, '\033[32m'+'OK'+'\033[0m')
 			else:
 				print("IPv4DNS resolution to", DOMAIN_NAME, '\033[31m'+'NG'+'\033[0m')
 		else:
 			result = subprocess.run(["dig", DOMAIN_NAME, "A", "@"+DNS_SERVER,"+short"], stdout=subprocess.PIPE)
-			if result.returncode == 0:
+			if result.stdout != b"":
 				print("IPv4DNS resolution to", DOMAIN_NAME, "with", DNS_SERVER, '\033[32m'+'OK'+'\033[0m')
 			else:
 				print("IPv4DNS resolution to", DOMAIN_NAME, "with", DNS_SERVER, '\033[31m'+'NG'+'\033[0m')
@@ -188,13 +188,13 @@ def check_dns_aaaa(DOMAIN_NAME, DNS_SERVER=None):
 		#DNS resolution check
 		if DNS_SERVER is None:
 			result = subprocess.run(["dig", DOMAIN_NAME, "AAAA", "+short"], stdout=subprocess.PIPE)
-			if result.returncode == 0:
+			if result.stdout != b"":
 				print("IPv6DNS resolution to", DOMAIN_NAME, '\033[32m'+'OK'+'\033[0m')
 			else:
 				print("IPv6DNS resolution to", DOMAIN_NAME, '\033[31m'+'NG'+'\033[0m')
 		else:
 			result = subprocess.run(["dig", DOMAIN_NAME, "AAAAA", "@"+DNS_SERVER,"+short"], stdout=subprocess.PIPE)
-			if result.returncode == 0:
+			if result.stdout != b"":
 				print("IPv6DNS resolution to", DOMAIN_NAME, "with", DNS_SERVER, '\033[32m'+'OK'+'\033[0m')
 			else:
 				print("IPv6DNS resolution to", DOMAIN_NAME, "with", DNS_SERVER, '\033[31m'+'NG'+'\033[0m')
@@ -247,7 +247,6 @@ def main():
 	check_dns_a(GOOGLE_DOMAIN)
 	check_dns_a(GOOGLE_DOMAIN, GOOGLE_DNS_IPV4)
 	check_dns_aaaa(GOOGLE_DOMAIN)
-	check_dns_aaaa(GOOGLE_DOMAIN, GOOGLE_DNS_IPV4)
 	print(" ")
 	print("------------http------------")
 	check_http(GOOGLE_IPV4)


### PR DESCRIPTION
DNSチェックの判定を`returncode`でしていたが正常に判定できていないことがわかったため修正
`stdout`で返される文字列の有無で判定する

NGの`result`結果
```
CompletedProcess(args=['dig', 'google.com', 'AAAA', '+short'], returncode=0, stdout=b'')
```